### PR TITLE
Fix flex stacking order bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ function creates_stacking_context(node) {
 
 	// https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context
 	if (style.position === 'fixed') return true;
-	if ((style.zIndex !== 'auto' && style.position !== 'static') || is_flex_item(node)) return true;
+	if (style.zIndex !== 'auto' && (style.position !== 'static' || is_flex_item(node))) return true;
 	if (+style.opacity < 1) return true;
 	if ('transform' in style && style.transform !== 'none') return true;
 	if ('webkitTransform' in style && style.webkitTransform !== 'none') return true;

--- a/test/samples/flex-with-z-index.html
+++ b/test/samples/flex-with-z-index.html
@@ -1,0 +1,6 @@
+<div style="display: flex; flex-direction: column">
+	<div class="flex: 0 0 2em; position: relative; overflow: visible">
+		<div data-front style="position: absolute; bottom: -2rem; height: 2rem; z-index: 2"></div>
+	</div>
+	<div data-back style="flex: 0 0 2em; position: relative"></div>
+</div>

--- a/test/samples/flex.html
+++ b/test/samples/flex.html
@@ -1,0 +1,6 @@
+<div style="display: flex; flex-direction: column">
+	<div class="flex: 0 0 2em; position: relative; overflow: visible">
+		<div data-back style="position: absolute; bottom: -2rem; height: 2rem"></div>
+	</div>
+	<div data-front style="flex: 0 0 2em; position: relative"></div>
+</div>


### PR DESCRIPTION
Fixes #3

## Before fix
```
➜ stacking-order (issues/3) ✔ node test/test.js
✗ flex-with-z-index
✓ flex
✓ nested-z-index
✓ ordered
✓ shadow-dom
✓ static-shadow-dom
✓ static-z-index
✓ z-index
7 passed
```

## After fix
```
➜ stacking-order (issues/3) ✔ node test/test.js
✓ flex-with-z-index
✓ flex
✓ nested-z-index
✓ ordered
✓ shadow-dom
✓ static-shadow-dom
✓ static-z-index
✓ z-index
8 passed
```